### PR TITLE
Add demo Flutter app skeleton

### DIFF
--- a/apps/pokemon_tcg_scanner/README.md
+++ b/apps/pokemon_tcg_scanner/README.md
@@ -1,0 +1,22 @@
+# Pokémon TCG Scanner Demo App
+
+This is a demo Flutter application for iOS that allows users to scan Pokémon TCG cards and manage them in a personal collection.
+
+## Features
+
+- **Scan Cards**: Uses the device camera to capture card images. (Scanning logic mocked with demo data.)
+- **Top Cards**: Shows most valuable cards in the user's collection.
+- **Recommended to Sell**: Displays cards recommended for sale based on mock market trends.
+- **Recommended to Grade (PSA)**: Lists cards that would benefit from professional grading.
+- **Auction House**: Simple listing interface where users can put cards up for sale.
+
+This demo focuses on UI structure and uses static demo data. Replace the mocked data and scanning logic with real implementations when integrating into production.
+
+## Running the App
+
+1. Install Flutter on your machine.
+2. Navigate to this directory and run:
+   ```bash
+   flutter run
+   ```
+

--- a/apps/pokemon_tcg_scanner/assets/demo/placeholder.txt
+++ b/apps/pokemon_tcg_scanner/assets/demo/placeholder.txt
@@ -1,0 +1,1 @@
+Demo image placeholder

--- a/apps/pokemon_tcg_scanner/lib/main.dart
+++ b/apps/pokemon_tcg_scanner/lib/main.dart
@@ -1,0 +1,144 @@
+import 'package:flutter/material.dart';
+
+void main() {
+  runApp(const PokemonTcgScannerApp());
+}
+
+class PokemonTcgScannerApp extends StatelessWidget {
+  const PokemonTcgScannerApp({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Pokémon TCG Scanner',
+      theme: ThemeData(primarySwatch: Colors.blue),
+      home: const HomePage(),
+    );
+  }
+}
+
+class HomePage extends StatefulWidget {
+  const HomePage({Key? key}) : super(key: key);
+
+  @override
+  State<HomePage> createState() => _HomePageState();
+}
+
+class _HomePageState extends State<HomePage> {
+  int _selectedIndex = 0;
+
+  final List<Widget> _pages = const [
+    ScanPage(),
+    CollectionPage(),
+    AuctionPage(),
+  ];
+
+  void _onItemTapped(int index) {
+    setState(() {
+      _selectedIndex = index;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Pokémon TCG Scanner')),
+      body: _pages[_selectedIndex],
+      bottomNavigationBar: BottomNavigationBar(
+        items: const [
+          BottomNavigationBarItem(icon: Icon(Icons.camera_alt), label: 'Scan'),
+          BottomNavigationBarItem(icon: Icon(Icons.collections), label: 'Collection'),
+          BottomNavigationBarItem(icon: Icon(Icons.store), label: 'Auction'),
+        ],
+        currentIndex: _selectedIndex,
+        onTap: _onItemTapped,
+      ),
+    );
+  }
+}
+
+class ScanPage extends StatelessWidget {
+  const ScanPage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          const Icon(Icons.camera_alt, size: 80),
+          const SizedBox(height: 20),
+          const Text('Scanning not implemented. Using demo data.'),
+          ElevatedButton(
+            onPressed: () {
+              // In a real app, trigger camera scanning here.
+            },
+            child: const Text('Scan Card'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class CollectionPage extends StatelessWidget {
+  const CollectionPage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final demoCards = [
+      {'name': 'Charizard', 'value': '\$500', 'grade': '9'},
+      {'name': 'Pikachu', 'value': '\$300', 'grade': '8'},
+      {'name': 'Blastoise', 'value': '\$450', 'grade': '7'},
+    ];
+
+    final topCards = demoCards.take(2).toList();
+    final recommendedToSell = demoCards.where((c) => c['value'] == '\$500').toList();
+    final recommendedToGrade = demoCards.where((c) => c['grade'] == '7').toList();
+
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text('Top Cards', style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
+          ...topCards.map((c) => ListTile(title: Text(c['name']!), subtitle: Text('Value: ${c['value']}'))),
+          const SizedBox(height: 20),
+          const Text('Recommended to Sell', style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
+          ...recommendedToSell.map((c) => ListTile(title: Text(c['name']!), subtitle: Text('Value: ${c['value']}'))),
+          const SizedBox(height: 20),
+          const Text('Recommended to Grade (PSA)', style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
+          ...recommendedToGrade.map((c) => ListTile(title: Text(c['name']!), subtitle: Text('Current Grade: ${c['grade']}'))),
+        ],
+      ),
+    );
+  }
+}
+
+class AuctionPage extends StatelessWidget {
+  const AuctionPage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final auctionItems = [
+      {'name': 'Charizard', 'price': '\$700'},
+      {'name': 'Pikachu', 'price': '\$350'},
+    ];
+
+    return ListView.builder(
+      itemCount: auctionItems.length,
+      itemBuilder: (context, index) {
+        final item = auctionItems[index];
+        return ListTile(
+          leading: const Icon(Icons.sell),
+          title: Text(item['name']!),
+          subtitle: Text('Starting price: ${item['price']}'),
+          trailing: ElevatedButton(
+            onPressed: () {},
+            child: const Text('Bid'),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/apps/pokemon_tcg_scanner/pubspec.yaml
+++ b/apps/pokemon_tcg_scanner/pubspec.yaml
@@ -1,0 +1,25 @@
+name: pokemon_tcg_scanner
+description: A demo Flutter app for scanning Pokémon TCG cards using the camera.
+publish_to: 'none'
+version: 0.1.0
+
+environment:
+  sdk: '>=2.17.0 <3.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  cupertino_icons: ^1.0.2
+
+  # Placeholder dependencies for camera and ML scanning
+  camera: ^0.10.0
+  provider: ^6.0.0
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true
+  assets:
+    - assets/demo/


### PR DESCRIPTION
## Summary
- add a Flutter demo app under `apps/pokemon_tcg_scanner`
- include skeleton UI for scanning, collection, and auction views
- include demo data and placeholder assets

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68602dd0e8d08327bb7f1b2000265b5c